### PR TITLE
Faster Travis builds using their container based infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
+sudo: false  # Use travis' container based infra
 language: python
 python:
     - "2.7"
     - "3.2"
     - "3.3"
     - "3.4"
-install: "pip install -r requirements.txt"
+cache:
+  directories:
+    - $PWD/wheelhouse  # cache the dependencies
+env:
+  global:
+    - export PIP_FIND_LINKS=$PWD/wheelhouse
+install:
+  - pip wheel -r requirements.txt
+  - pip install -r requirements.txt
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 Topy
 ====
+.. image:: https://travis-ci.org/intgr/topy.svg?branch=master
+   :alt: Travis CI
+   :target: http://travis-ci.org/intgr/topy
 
 Topy (anagram of "typo") is a Python script to fix typos in text, using rulesets developed by the RegExTypoFix_ project
 from Wikipedia. The English ruleset is included with Topy and is used by default. Other rulesets can be manually

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -1,5 +1,5 @@
+# -*- coding: utf-8 -*-
 """Unit tests for internal functions"""
-# encoding=utf-8
 
 from __future__ import unicode_literals
 


### PR DESCRIPTION
- Travis CI's container based infra makes builds faster, also it allows
caching dependencies so as to cut down on build time.
 - unit.py changed to set encoding to utf-8 as the build environment
 doesn't respect #coding = utf8
- a badge added to README showing the current build status

After caching, travis builds complete in ~35 seconds or so compared to the minute and a half time spent right now