### PR TITLE
Travis CI: Fix PyPy build, add Python 3.8, drop 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 sudo: false  # Use travis' container based infra
 language: python
-dist: xenial
+dist: focal
 # Versions are deliberately out of order to get a diverse sample first
 python:
-  - 3.7
-  - 2.7
+  - 3.8
   - 3.5
   - 3.6
-  - pypy3.5
-cache:
-  directories:
-    - $PWD/wheelhouse  # cache the dependencies
-env:
-  global:
-    - export PIP_FIND_LINKS=$PWD/wheelhouse
+  - 3.7
+  - pypy3
+cache: pip
 install:
   - pip wheel -r requirements.txt
   - pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ downloaded.
 
 .. _RegExTypoFix: https://en.wikipedia.org/wiki/Wikipedia:AutoWikiBrowser/Typos
 
-Topy works with Python 2.7 and 3.5-3.7.
+Topy works with Python 3.5-3.8.
 
 The easiest way to install it is using pip::
 


### PR DESCRIPTION
* Updated to Ubuntu 20.04-based image (Ubuntu Focal Fossa).
* Fixed pip caching