### PR TITLE
CI: Enable testing with Python 3.11, 3.10, drop 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ downloaded.
 
 .. _RegExTypoFix: https://en.wikipedia.org/wiki/Wikipedia:AutoWikiBrowser/Typos
 
-Topy works with Python 3.6-3.9.
+Topy works with Python 3.7-3.11.
 
 The easiest way to install it is using pip::
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         # Until we have a test suite we're conservative about Python version compatibility claims
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Documentation',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Text Processing :: Filters',

--- a/topy/topy.py
+++ b/topy/topy.py
@@ -3,7 +3,7 @@
 Topy (anagram of "typo") is a Python script to fix typos in text, based on
 the RegExTypoFix project from Wikipedia and AutoWikiBrowser.
 
-Topy requires BeautifulSoup version 4 and runs with Python 3.6+
+Topy requires BeautifulSoup version 4 and runs with Python 3.7+
 
 Usage: ./topy.py /path/to/files
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
GitHub Actions has issues with Python 3.6 and it's EOL anyway.